### PR TITLE
이전 버튼 인덱스 값 Math.max 으로 수정

### DIFF
--- a/client/src/pages/ResumeBuilder.jsx
+++ b/client/src/pages/ResumeBuilder.jsx
@@ -53,6 +53,7 @@ const ResumeBuilder = () => {
     { id: "skills", name: "Skills", icon: Sparkles },
   ];
 
+
   const activeSection = sections[activeSectionIndex];
 
   useEffect(() => {
@@ -88,7 +89,6 @@ const ResumeBuilder = () => {
                 />
 
                 {/* Section Navigation */}
-
                 <div className="flex justify-between items-center mb-6 border-b border-gray-300 py-1">
                   <div></div>
 
@@ -97,7 +97,7 @@ const ResumeBuilder = () => {
                       <button
                         onClick={() =>
                           setActiveSectionIndex((prevIndex) =>
-                            Math.min(prevIndex - 1, 0)
+                            Math.max(prevIndex - 1, 0)
                           )
                         }
                         className="flex items-center gap-1 p-3 rounded-lg text-sm font-medium text-gray-600 hover-gray-50 transition-all"
@@ -115,12 +115,17 @@ const ResumeBuilder = () => {
                             ${activeSectionIndex === sections.length -1 && 'opacity-50'}`}
                       disabled={activeSectionIndex === sections.length -1}
                     >
-
                       다음
                       <ChevronRight className="size-4" />
                     </button>
                   </div>
                 </div>
+
+                {/* Form Content */}
+                <div className="space">
+
+                </div>
+
               </div>
               {sections.map((menu) => {
                 return <p key={menu.id}>{menu.name}</p>;


### PR DESCRIPTION
이전/다음 버튼을 눌러서 현재 섹션 번호(activeSectionIndex)를 바꾸는 코드

`{activeSectionIndex !== 0 &&  `

처음 섹션 (값이 0인 초기 상태 ) 에는 이전 버튼이 안보이도록 설정함 
 0이 아닐 경우 이전 버튼을 보여줌 

```
  onClick={() =>
    setActiveSectionIndex((prevIndex) =>
      Math.max(prevIndex - 1, 0)
    )
  }
```
현재 인덱스(prevIndex) 에서 1을 빼는데 0 아래로 내려가지 않도록함
Math.max(a, b) a와 b 중 더 큰 값을 반환 -> 0보다 큰 값을 반환 
 
`disabled={activeSectionIndex === 0}`
첫페이지 상태일 때 클릭 방지


```
  onClick={() =>
    setActiveSectionIndex((prevIndex) =>
      Math.min(prevIndex + 1, sections.length -1)
    )
  }
```
마지막 인덱스를 넘으면 마지막 인덱스로 고정해서 넘어가지 않도록 고정